### PR TITLE
Fix middleware filter

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -92,7 +92,7 @@ app
         pkgs = mwList.filter((el: any) => {
           const query = req.query.q as string
 
-          return el.name.indexOf(query.toLowerCase()) > -1
+          return el.indexOf(query.toLowerCase()) > -1
         })
       }
 


### PR DESCRIPTION
Middleware search is currently broken with a `Cannot read property 'indexOf' of undefined` error.

I think this should fix it.