### PR TITLE
The example for `req.ips` in docs was instead an example for `req.ip`.

### DIFF
--- a/views/pages/docs.eta
+++ b/views/pages/docs.eta
@@ -723,7 +723,7 @@ console.log(req.ip)
 Contains an array of remote IP addresses of the request.
 
 ```ts
-console.log(req.ip)
+console.log(req.ips)
 // => [127.0.0.1']
 ```
 


### PR DESCRIPTION
The example for `req.ips` in docs was instead an example for `req.ip`.

```js
console.log(req.ip)
// => [127.0.0.1']
```