### PR TITLE
Restore heading ids after update to Marked v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eta": "^2.2.0",
     "lru-send": "^0.1.3",
     "marked": "^7.0.3",
+    "marked-gfm-heading-id": "^3.0.7",
     "marked-highlight": "^2.0.4",
     "node-fetch-cache": "^3.1.3",
     "quick-lru": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   marked:
     specifier: ^7.0.3
     version: 7.0.3
+  marked-gfm-heading-id:
+    specifier: ^3.0.7
+    version: 3.0.7(marked@7.0.3)
   marked-highlight:
     specifier: ^2.0.4
     version: 2.0.4(marked@7.0.3)
@@ -1013,6 +1016,7 @@ packages:
   /cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -1077,6 +1081,7 @@ packages:
   /denque@1.5.1:
     resolution: {integrity: sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==}
     engines: {node: '>=0.10'}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -1379,6 +1384,10 @@ packages:
       resolve-pkg-maps: 1.0.0
     dev: true
 
+  /github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+    dev: false
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1567,16 +1576,19 @@ packages:
 
   /lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    requiresBuild: true
     dev: false
     optional: true
 
   /lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+    requiresBuild: true
     dev: false
     optional: true
 
   /lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -1599,6 +1611,15 @@ packages:
       ioredis: 4.28.5
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /marked-gfm-heading-id@3.0.7(marked@7.0.3):
+    resolution: {integrity: sha512-8JtFnp8/50qwpwwt446Uv4Ohy0jDLNGnAB7sWln7SLQcQQV7+K3qlMMwYupELz9cZvKKiRqXHEGNopcEvxM2ew==}
+    peerDependencies:
+      marked: '>=4 <9'
+    dependencies:
+      github-slugger: 2.0.0
+      marked: 7.0.3
     dev: false
 
   /marked-highlight@2.0.4(marked@7.0.3):
@@ -1765,6 +1786,7 @@ packages:
   /p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -1836,18 +1858,21 @@ packages:
 
   /redis-commands@1.7.0:
     resolution: {integrity: sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==}
+    requiresBuild: true
     dev: false
     optional: true
 
   /redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dev: false
     optional: true
 
   /redis-parser@3.0.0:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       redis-errors: 1.2.0
     dev: false
@@ -1947,6 +1972,7 @@ packages:
 
   /standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    requiresBuild: true
     dev: false
     optional: true
 

--- a/server.ts
+++ b/server.ts
@@ -7,6 +7,7 @@ import * as eta from 'eta'
 import { EtaConfig } from 'eta/dist/types/config'
 import { Marked } from 'marked'
 import { markedHighlight } from 'marked-highlight'
+import { gfmHeadingId } from 'marked-gfm-heading-id'
 import shiki from 'shiki'
 import { lruSend } from 'lru-send'
 import { fetchBuilder, FileSystemCache } from 'node-fetch-cache'
@@ -87,7 +88,8 @@ async function startApp() {
 
         return hl.codeToHtml(code, { lang })
       },
-    })
+    }),
+    gfmHeadingId()
   )
 
   app


### PR DESCRIPTION
The navigation links were broken by the upgrade to Marked v7, which defaults to not generating ids for Markdown headings. This option is completely removed in v8. This PR fixes the navigation links by using the new [marked-gfm-heading-id](https://github.com/markedjs/marked-gfm-heading-id) plugin.